### PR TITLE
docs: markdownlintに合わせて修正した

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,14 +1,14 @@
 # License
 
-Copyright (c) 2022, Hiroshi Miura (https://github.com/hirmiura)
+Copyright (c) 2022, Hiroshi Miura <https://github.com/hirmiura>
 with Reserved Font Name TamaTou.
 
 These font softwares are licensed under the [SIL Open Font License].
 
--   Products font
-    -   Sika
--   Source fonts
-    -   Cica
+- Products font
+  - Sika
+- Source fonts
+  - Cica
 
 Other scripts and codes are licensed under the [MIT License].
 


### PR DESCRIPTION
フォーマッタを Prettier から Markdown All in One に変更した。
空白数の過剰を削除した。
URLをアングルブラケットで囲うように修正した。